### PR TITLE
JSDoc 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "inert": "^3.2.0",
     "jade": "^1.11.0",
     "joi": "^7.0.0",
-    "jsdoc": "github:jsdoc3/jsdoc",
+    "jsdoc": "^3.4.0",
     "libxmljs": "^0.15.0",
     "lodash": "^3.10.1",
     "lout": "^7.2.0",


### PR DESCRIPTION
* Moves jsdoc from source to latest release
* Officially supports Node 4+ and ES2015 features