### PR TITLE
Cleanup Lint Configuration

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -76,7 +76,7 @@ rules:
     no-iterator: 2
     no-labels: 2
     no-lone-blocks: 2
-    no-loop-func: 2
+    no-loop-func: 0 # no-var
     no-magic-numbers: 2
     no-multi-spaces: 2
     no-multi-str: 2
@@ -171,7 +171,7 @@ rules:
         - 120
     max-nested-callbacks:
         - 2
-        - 1
+        - 2
     max-params: 2
     max-statements: 2
     new-cap: 2

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -1,4 +1,0 @@
-rules:
-    max-nested-callbacks:
-        - 2
-        - 2

--- a/modules/code-project/task/.eslintrc.yml
+++ b/modules/code-project/task/.eslintrc.yml
@@ -3,10 +3,6 @@ rules:
     max-params:
         - 2
         - 4
-    max-nested-callbacks:
-        - 2
-        - 2
     max-statements:
         - 2
         - 14
-    no-loop-func: 0

--- a/modules/code-project/view/.eslintrc.yml
+++ b/modules/code-project/view/.eslintrc.yml
@@ -1,9 +1,6 @@
 rules:
     camelcase: 0
     max-len: 0
-    max-nested-callbacks:
-        - 2
-        - 2
     max-statements:
         - 2
         - 14

--- a/modules/import-export/task/.eslintrc.yml
+++ b/modules/import-export/task/.eslintrc.yml
@@ -1,7 +1,4 @@
 rules:
-    max-nested-callbacks:
-        - 2
-        - 2
     max-statements:
         - 2
         - 14

--- a/modules/team/api/.eslintrc.yml
+++ b/modules/team/api/.eslintrc.yml
@@ -1,4 +1,0 @@
-rules:
-    max-nested-callbacks:
-        - 2
-        - 2

--- a/modules/user/api/.eslintrc.yml
+++ b/modules/user/api/.eslintrc.yml
@@ -1,4 +1,0 @@
-rules:
-    max-nested-callbacks:
-        - 2
-        - 2

--- a/tasks/.eslintrc.yml
+++ b/tasks/.eslintrc.yml
@@ -1,6 +1,3 @@
 rules:
     global-require: 0
-    max-nested-callbacks:
-        - 2
-        - 2
     no-sync: 0


### PR DESCRIPTION
* `no-loop-func` applies when `var` is being used, Nicest bans `var`
* Increase `max-nested-callbacks` to 2 to overall