### PR TITLE
Automatically run lint checks before commits and pushes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "nicest": "bin/cli.js"
   },
   "scripts": {
+    "precommit": "npm test",
+    "prepush": "npm test",
     "postinstall": "jsdoc --recurse lib modules tasks --destination docs",
     "test": "eslint . --inline-config=false && pug-lint modules && remark *.md modules/**/*.md"
   },
@@ -67,6 +69,7 @@
   },
   "devDependencies": {
     "eslint": "^3.12.2",
+    "husky": "^0.13.1",
     "pug-lint": "^2.3.0",
     "remark-cli": "^2.1.0",
     "remark-preset-lint-consistent": "^1.0.0",
@@ -74,6 +77,7 @@
     "remark-validate-links": "^5.0.0"
   },
   "eslintConfig": {
+    "root": true,
     "extends": "eslint:all",
     "env": {
       "node": true,


### PR DESCRIPTION
To test run

``` sh
npm install
```

to updated dependencies.
Then commit and push as you would usually.

resolves #440 