### PR TITLE
build(npm): require node 8 and npm 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/ChristianMurphy/nicest#readme",
   "engines": {
-    "node": "^6.0.0",
-    "npm": ">=3.8.0"
+    "node": "^8.0.0",
+    "npm": "^5.1.0"
   },
   "files": [
     "bin",


### PR DESCRIPTION
version updates open the door for using more recent javascript features
as well as leveraging the new package lockfile for more exact versioning

BREAKING CHANGE: drops support for node version 7 and below,
also drops support for npm version 4 and below