### PR TITLE
ci(travis): remove greenkeeper upload lockfile step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ node_js: 8
 
 before_install: npm i -g greenkeeper-lockfile@1
 install: npm install --ignore-scripts
-
 before_script: greenkeeper-lockfile-update
-after_script: greenkeeper-lockfile-upload
 
 cache:
   directories:


### PR DESCRIPTION
There is a risk of leaking write key to make this work, without the write key it will fail.